### PR TITLE
updated to work with configurations without zpool.cache as it's no longe...

### DIFF
--- a/beadm
+++ b/beadm
@@ -499,7 +499,7 @@ EOF
         then
           cp /boot/zfs/zpool.cache ${TMPMNT}/boot/zfs/zpool.cache
         else
-          rm ${TMPMNT}/boot/zfs/zpool.cache
+          rm -f ${TMPMNT}/boot/zfs/zpool.cache
         fi
         LOADER_CONFIGS=${TMPMNT}/boot/loader.conf
         if [ -f ${TMPMNT}/boot/loader.conf.local ]

--- a/beadm
+++ b/beadm
@@ -495,7 +495,12 @@ EOF
         else
           TMPMNT=${MOUNT}
         fi
-        cp /boot/zfs/zpool.cache ${TMPMNT}/boot/zfs/zpool.cache
+        if [ -f /boot/zfs/zpool.cache ]
+        then
+          cp /boot/zfs/zpool.cache ${TMPMNT}/boot/zfs/zpool.cache
+        else
+          rm ${TMPMNT}/boot/zfs/zpool.cache
+        fi
         LOADER_CONFIGS=${TMPMNT}/boot/loader.conf
         if [ -f ${TMPMNT}/boot/loader.conf.local ]
         then


### PR DESCRIPTION
On single zpool setups it's no longer required to have a spool.cache , so this adds a check. 
Problematic might be if one is going back to an old OS and the zpool.cache might be needed as it is now removed.
