### PR TITLE
Fix for oddities with ZFS bookmarks

### DIFF
--- a/beadm
+++ b/beadm
@@ -280,7 +280,7 @@ case ${1} in
             MOUNTS[$1] = $3
         close(CMD_MOUNT)
         FS = "\\t"
-        CMD_ZFS_LIST = "zfs list -H -t all -s creation -o name,used,usedds,usedbysnapshots,usedrefreserv,refer,creation,origin -r "
+        CMD_ZFS_LIST = "zfs list -H -t filesystem,snapshot,volume -s creation -o name,used,usedds,usedbysnapshots,usedrefreserv,refer,creation,origin -r "
         while(CMD_ZFS_LIST BENAME_BEGINS_WITH | getline) {
           if($1 != BENAME_BEGINS_WITH) {
             FSNAME = $1
@@ -599,7 +599,7 @@ EOF
           if __be_clone ${POOL}/${BEDS}/${DESTROY}
           then
             # promote clones dependent on snapshots used by destroyed boot environment
-            zfs list -H -t all -o name,origin -r ${POOL} \
+            zfs list -H -t filesystem,snapshot,volume -o name,origin -r ${POOL} \
               | while read NAME ORIGIN
                 do
                   if echo "${ORIGIN}" | grep -q -E "${POOL}/${BEDS}/${DESTROY}(/.*@|@)" 2> /dev/null
@@ -608,7 +608,7 @@ EOF
                   fi
                 done
             # get origins used by destroyed boot environment
-            ORIGIN_SNAPSHOTS=$( zfs list -H -t all -o origin -r ${POOL}/${BEDS}/${DESTROY} | grep -v '^-$' | awk -F "@" '{print $2}' | sort -u )
+            ORIGIN_SNAPSHOTS=$( zfs list -H -t filesystem,snapshot,volume -o origin -r ${POOL}/${BEDS}/${DESTROY} | grep -v '^-$' | awk -F "@" '{print $2}' | sort -u )
           fi
           # check if boot environment was created from existing snapshot
           ORIGIN=$( zfs list -H -o origin ${POOL}/${BEDS}/${DESTROY} )
@@ -642,7 +642,7 @@ EOF
           if __be_clone ${POOL}/${BEDS}/${DESTROY}
           then
             # promote datasets dependent on origins used by destroyed boot environment
-            ALL_ORIGINS=$( zfs list -H -t all -o name,origin -r ${POOL} )
+            ALL_ORIGINS=$( zfs list -H -t filesystem,snapshot,volume -o name,origin -r ${POOL} )
             echo "${ORIGIN_SNAPSHOTS}" \
               | while read S
                 do


### PR DESCRIPTION
The upcoming FreeBSD 10.1 release adds ZFS bookmarks.

While playing around with bookmarks, I noticed issues with "beadm list", e.g.:

    > beadm list
    BE                        Active Mountpoint  Space Created
    default                   -      -            4.9M 2014-09-22 20:51
    10.1-BETA3                -      -          109.2M 2014-09-28 18:54
    10.1-RC1                  NR     /            3.6G 2014-10-05 19:15
    zroot                     -      /            0.0K 2014-10-05 19:15
    10.1-BETA3#incbackup-last -      -            0.0K 2014-10-16 20:28
    10.1-RC1#incbackup-last   -      -            0.0K 2014-10-16 20:28
    default#incbackup-last    -      -            0.0K 2014-10-16 20:28

Contrast this to a properly behaving beadm:

    > ./beadm list
    BE         Active Mountpoint  Space Created
    default    -      -            4.9M 2014-09-22 20:51
    10.1-BETA3 -      -          109.2M 2014-09-28 18:54
    10.1-RC1   NR     /            3.6G 2014-10-05 19:15

The issue seems to stem from the use of the "-t all" option to "zfs list." In older versions of FreeBSD, "-t all" simply was equivalent to "-t filesystem,snapshot,volume." But now it includes bookmarks. My fix simply replaces occurrences of "-t all" with "-t filesystem,snapshot,volume." Arguably, only filesystem and snapshot are relevant to beadm, so the list can probably be reduced down to just those two.

This change would only affect "beadm list" and "beadm destroy." I don't believe the presence of bookmarks would affect "beadm destroy," but I thought it would be safer to replace "-t all" there anyway.