### PR TITLE
Always set canmount=noauto when doing new BE's

### DIFF
--- a/beadm
+++ b/beadm
@@ -842,14 +842,7 @@ EOF
       | grep -E "^${POOL}/${BEDS}/${ACTBE}(/|$)" \
       | while read NAME
         do
-          # If we are using GRUB, don't set canmount=on, since it clobbers
-          # what we set in grub.cfg for vfs.root.mountfrom
-          if [ -e /boot/grub/grub.cfg ]
-          then
-            zfs set canmount=noauto ${NAME}
-          else
-            zfs set canmount=on ${NAME}
-          fi
+          zfs set canmount=noauto ${NAME}
           while __be_clone ${NAME}
           do
             zfs promote ${NAME}


### PR DESCRIPTION
This fixes an issue using BE's with FreeBSD's loader on upcoming 11.0. Need to always use canmount=noauto