### PR TITLE
Support boot-time selection of BE.

### DIFF
--- a/beadm
+++ b/beadm
@@ -492,6 +492,7 @@ case ${1} in
         fi
       fi
       # do not change root (/) mounted boot environment mountpoint
+      HAVE_ZFSBE=0
       if [ "${ROOTFS}" != "${POOL}/${BEDS}/${2}" ]
       then
         TMPMNT=$( mktemp -d -t BE-${2} )
@@ -518,6 +519,9 @@ EOF
           zfs mount ${POOL}/${BEDS}/${2}
         else
           TMPMNT=${MOUNT}
+        fi
+        if [ -f ${TMPMNT}/etc/rc.d/zfsbe ]; then
+          HAVE_ZFSBE=1
         fi
         if [ -f /boot/zfs/zpool.cache ]
         then
@@ -555,11 +559,16 @@ EOF
           zfs set canmount=noauto ${NAME}
         done
     # enable automatic mount for active boot environment and promote it
+    if [ ${HAVE_ZFSBE} -eq 1 ]; then
+      ZFSBE_CANMOUNT=noauto
+    else
+      ZFSBE_CANMOUNT=on
+    fi
     echo "${ZFS_LIST}" \
       | grep -E "^${POOL}/${BEDS}/${2}(/|$)" \
       | while read NAME
         do
-          zfs set canmount=on ${NAME}
+          zfs set canmount=${ZFSBE_CANMOUNT} ${NAME}
           while __be_clone ${NAME}
           do
             zfs promote ${NAME}


### PR DESCRIPTION
If the /etc/rc.d/zfsbe script exists then set the mountpoints to 'noauto'
since the rc script will mount any needed datasets at boottime.  Otherwise
use 'on' to support child datasets in zroot/ROOT/<BE> that would not
be mounted without the rc script or fstab entries.

Reviewed by:	Allan Jude