### PR TITLE
Make newly activated BE work with reboot -r

### DIFF
--- a/beadm
+++ b/beadm
@@ -625,6 +625,8 @@ EOF
     then
       __update_grub
     fi
+    # allow reboot -r to change to the new root filesystem
+    kenv vfs.root.mountfrom="zfs:${POOL}/${BEDS}/${2}" 1>/dev/null 2>/dev/null
     echo "Activated successfully"
     ;;
 


### PR DESCRIPTION
Set `vfs.root.mountfrom` to the activated BE so `reboot -r` works.  This can be convenient e.g. when FreeBSD updates only affect userspace and there is no need to reboot the kernel.