### PR TITLE
Skip readonly zfs properties during zfs clone

### DIFF
--- a/beadm
+++ b/beadm
@@ -244,13 +244,20 @@ __be_new() { # 1=SOURCE 2=TARGET
         local OPTS=""
         while read NAME PROPERTY VALUE
         do
-          if [ "${VALUE}" != "" ]
-          then
-            local OPTS="-o ${PROPERTY}=\"${VALUE}\" ${OPTS}"
-          else
-            local OPTS=""
-            break
-          fi
+          case $PROPERTY in
+			  snapshot_count|filesystem_count)
+				  # Read only property, skip
+				  ;;
+			  *)
+				if [ "${VALUE}" != "" ]
+				then
+				  local OPTS="-o ${PROPERTY}=\"${VALUE}\" ${OPTS}"
+				else
+				  local OPTS=""
+				  break
+				fi
+				;;
+		  esac
         done << EOF
 $( zfs get -o name,property,value -s local,received -H all ${FS} | awk '!/[\t ]canmount[\t ]/' )
 EOF


### PR DESCRIPTION
Using 1.3.5. of beadm on a FreeBSD system I got the following message

```
sudo beadm create pre-fbsd13.1
cannot create 'system/ROOT/pre-fbsd13.1': 'snapshot_count' is readonly
```

Apparently some properties are readonly in the openzfs code and cannot be used with zfs clone. 
The patch wields them out (for now, snapshot_count/filesystem_count)